### PR TITLE
Updated build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.19.+'
-    compile 'com.google.android.gms:play-services-maps:8.4.0'
-    compile 'com.google.maps.android:android-maps-utils:0.4'
+    implementation 'com.facebook.react:react-native:0.19.+'
+    implementation 'com.google.android.gms:play-services-maps:8.4.0'
+    implementation 'com.google.maps.android:android-maps-utils:0.4'
 }


### PR DESCRIPTION
Configuration 'compile' is obsolete and has been replaced with 'implementation'.

**Fixes** #15 